### PR TITLE
Modify researcher role

### DIFF
--- a/MoreUserRolesPlugin.php
+++ b/MoreUserRolesPlugin.php
@@ -28,7 +28,7 @@ class MoreUserRolesPlugin extends Omeka_Plugin_AbstractPlugin
 		$acl->allow('editor','Users',array('browse'));
 	    
         // RESEARCHERS (existing role) given the ability to view unpublished Exhibits 
-	   	if (plugin_is_active(‘ExhibitBuilder’)) {
+	   	if (plugin_is_active('ExhibitBuilder')) {
 			$acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');   
 	   	}
 		

--- a/MoreUserRolesPlugin.php
+++ b/MoreUserRolesPlugin.php
@@ -41,7 +41,7 @@ class MoreUserRolesPlugin extends Omeka_Plugin_AbstractPlugin
 				resortedRoles=[]
 				betterOrder.forEach(function(name){
 					var note=(name=='author'||name=='editor') ? ' (More User Roles plugin)' : '';
-					var note2=(name=='researcher') ? ' (More User Roles plugin modification) : '';
+					var note2=(name=='researcher') ? ' (More User Roles plugin modification)': '';
 					var opt='<option value="'+name+'">'+name.charAt(0).toUpperCase()+ name.slice(1)+note+note2+'</option>';
 					resortedRoles.push(opt);
 				});

--- a/MoreUserRolesPlugin.php
+++ b/MoreUserRolesPlugin.php
@@ -29,7 +29,7 @@ class MoreUserRolesPlugin extends Omeka_Plugin_AbstractPlugin
 	    
         // RESEARCHERS (existing role) given the ability to view unpublished Exhibits 
 	   	if (plugin_is_active(‘ExhibitBuilder’)) {
-             $acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');   
+			$acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');   
 	   	}
 		
     }

--- a/MoreUserRolesPlugin.php
+++ b/MoreUserRolesPlugin.php
@@ -26,6 +26,9 @@ class MoreUserRolesPlugin extends Omeka_Plugin_AbstractPlugin
 		$acl->allow('editor','Items',array('makeFeatured','edit','delete'));
 		$acl->allow('editor','Files',array('edit','delete'));
 		$acl->allow('editor','Users',array('browse'));
+	    
+        // RESEARCHERS (existing role) given the ability to view unpublished Exhibits 
+	    	$acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');
 		
     }
     
@@ -38,7 +41,8 @@ class MoreUserRolesPlugin extends Omeka_Plugin_AbstractPlugin
 				resortedRoles=[]
 				betterOrder.forEach(function(name){
 					var note=(name=='author'||name=='editor') ? ' (More User Roles plugin)' : '';
-					var opt='<option value="'+name+'">'+name.charAt(0).toUpperCase()+ name.slice(1)+note+'</option>';
+					var note2=(name=='researcher') ? ' (More User Roles plugin modification) : '';
+					var opt='<option value="'+name+'">'+name.charAt(0).toUpperCase()+ name.slice(1)+note+note2+'</option>';
 					resortedRoles.push(opt);
 				});
 				var parser = document.createElement('a');

--- a/MoreUserRolesPlugin.php
+++ b/MoreUserRolesPlugin.php
@@ -28,7 +28,9 @@ class MoreUserRolesPlugin extends Omeka_Plugin_AbstractPlugin
 		$acl->allow('editor','Users',array('browse'));
 	    
         // RESEARCHERS (existing role) given the ability to view unpublished Exhibits 
-	    	$acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');
+	   	if (plugin_is_active(‘ExhibitBuilder’)) {
+             $acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');   
+	   	}
 		
     }
     

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This plugin adds two new user roles to Omeka sites, modifies one, and lightly mo
 
 ## Form Modifications
 * Sorts user roles by "power" – from least to most – in the user admin dropdowns
-* Annotates which user roles are created by the plugin
+* Annotates which user roles are created or modified by the plugin
 * Adds a link to plugin documentation on Github.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # More User Roles
 
 ## Description
-This plugin adds two new user roles to Omeka sites and lightly modifies the admin user forms.
+This plugin adds two new user roles to Omeka sites, modifies one, and lightly modifies the admin user forms. 
 
 ## User Roles
 * **Authors** inherit the rights of Contributors but are able to publish their own items.\*
 * **Editors** inherit the rights of Authors but are able to edit and delete Items and Files created by other users and make items Featured.\*
 
 \* *When the plugin is uninstalled, Author and Editor users are demoted to the Contributor role.*
+
+* **Researchers** gain the ability to view unpublished Exhibits if Exhibit Builder is activated
 
 ## Form Modifications
 * Sorts user roles by "power" – from least to most – in the user admin dropdowns


### PR DESCRIPTION
Hi, thanks for the plugin! Not sure if you want to muddy your perfectly clear plugin, but I needed a role to view unpublished exhibit builder content ([and I don't seem to be the only one](https://forum.omeka.org/t/role-that-can-view-unpublished-material/6956/3)). It was easier to fork and modify this than create a new plugin from scratch. Offering it as a PR if you're interested in merging, but happy to keep our own fork active if not.

Cheers!